### PR TITLE
Increase heap size to avoid "Ooops, out of memory" errors (fix for issue #33)

### DIFF
--- a/SGit/AndroidManifest.xml
+++ b/SGit/AndroidManifest.xml
@@ -16,6 +16,7 @@
 
     <application
         android:allowBackup="true"
+        android:largeHeap="true" 
         android:icon="@drawable/ic_launcher"
         android:logo="@drawable/ic_logo"
         android:label="@string/app_name"


### PR DESCRIPTION
Successfully tested on a Samsung Galaxy S3 with a problematic repository. 
