### PR TITLE
Fixed duplicity of commit items in CommitsList at start of CommitFragmen...

### DIFF
--- a/SGit/src/me/sheimi/sgit/adapters/CommitsListAdapter.java
+++ b/SGit/src/me/sheimi/sgit/adapters/CommitsListAdapter.java
@@ -110,6 +110,7 @@ public class CommitsListAdapter extends SheimiArrayAdapter<RevCommit> {
                         // TODO Auto-generated method stub
                         if (commits != null) {
                             // TODO why == null
+                        	clear();
                             addAll(commits);
                         }
                         notifyDataSetChanged();


### PR DESCRIPTION
This commit fixes the bug when commits ale loaded twice into FragmentCommit's list view. CommitAdapter is clearing all items before adding new ones.
