### PR TITLE
Store private SSH keys in internal memory.

### DIFF
--- a/SGit/src/me/sheimi/android/utils/FsUtils.java
+++ b/SGit/src/me/sheimi/android/utils/FsUtils.java
@@ -6,6 +6,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import me.sheimi.android.activities.SheimiFragmentActivity;
 import me.sheimi.sgit.R;
 
 import org.apache.commons.io.FileUtils;
@@ -40,16 +41,25 @@ public class FsUtils {
         return getDir(dirname, true);
     }
 
-    public static File getDir(String dirname, boolean isCreate) {
-        File mDir = new File(getAppDir(), dirname);
+    public static File getInternalDir(String dirname) { return getDir(dirname, true, false); }
+
+    public static File getDir(String dirname, boolean isCreate) { return getDir(dirname, isCreate, true); }
+
+    public static File getDir(String dirname, boolean isCreate, boolean isExternal) {
+        File mDir = new File(getAppDir(isExternal), dirname);
         if (!mDir.exists() && isCreate) {
             mDir.mkdir();
         }
         return mDir;
     }
 
-    public static File getAppDir() {
-        return BasicFunctions.getActiveActivity().getExternalFilesDir(null);
+    public static File getAppDir(boolean isExternal) {
+        SheimiFragmentActivity activeActivity = BasicFunctions.getActiveActivity();
+        if (isExternal) {
+            return activeActivity.getExternalFilesDir(null);
+        } else {
+            return activeActivity.getFilesDir();
+        }
     }
 
     public static String getMimeType(String url) {

--- a/SGit/src/me/sheimi/sgit/RepoListActivity.java
+++ b/SGit/src/me/sheimi/sgit/RepoListActivity.java
@@ -17,6 +17,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ListView;
 import android.widget.SearchView;
+import me.sheimi.sgit.ssh.PrivateKeyUtils;
 
 public class RepoListActivity extends SheimiFragmentActivity {
 
@@ -29,6 +30,7 @@ public class RepoListActivity extends SheimiFragmentActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        PrivateKeyUtils.migratePrivateKeys();
         setContentView(R.layout.activity_main);
         mRepoList = (ListView) findViewById(R.id.repoList);
         mRepoListAdapter = new RepoListAdapter(this);

--- a/SGit/src/me/sheimi/sgit/activities/explorer/PrivateKeyManageActivity.java
+++ b/SGit/src/me/sheimi/sgit/activities/explorer/PrivateKeyManageActivity.java
@@ -3,6 +3,7 @@ package me.sheimi.sgit.activities.explorer;
 import java.io.File;
 import java.io.FileFilter;
 
+import me.sheimi.android.utils.BasicFunctions;
 import me.sheimi.android.utils.FsUtils;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.dialogs.RenameKeyDialog;
@@ -13,14 +14,23 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
+import me.sheimi.sgit.ssh.PrivateKeyUtils;
 
 public class PrivateKeyManageActivity extends FileExplorerActivity {
 
     private static final int REQUSET_ADD_KEY = 0;
 
     @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        BasicFunctions.setActiveActivity(this);
+        PrivateKeyUtils.migratePrivateKeys();
+
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
     protected File getRootFolder() {
-        return FsUtils.getDir("ssh");
+        return PrivateKeyUtils.getPrivateKeyFolder();
     }
 
     @Override

--- a/SGit/src/me/sheimi/sgit/ssh/PrivateKeyUtils.java
+++ b/SGit/src/me/sheimi/sgit/ssh/PrivateKeyUtils.java
@@ -1,0 +1,27 @@
+package me.sheimi.sgit.ssh;
+
+import me.sheimi.android.utils.FsUtils;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class PrivateKeyUtils {
+    private PrivateKeyUtils() {}
+
+    public static File getPrivateKeyFolder() {
+        return FsUtils.getInternalDir("ssh");
+    }
+
+    public static void migratePrivateKeys() {
+        File oldDir = FsUtils.getDir("ssh");
+        if (oldDir.exists()) {
+            try {
+                FileUtils.copyDirectory(oldDir, getPrivateKeyFolder());
+                FileUtils.deleteDirectory(oldDir);
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+}

--- a/SGit/src/me/sheimi/sgit/ssh/SGitSessionFactory.java
+++ b/SGit/src/me/sheimi/sgit/ssh/SGitSessionFactory.java
@@ -25,7 +25,8 @@ public class SGitSessionFactory extends JschConfigSessionFactory {
     @Override
     protected JSch createDefaultJSch(FS fs) throws JSchException {
         JSch jsch = new JSch();
-        File sshDir = FsUtils.getDir("ssh");
+        PrivateKeyUtils.migratePrivateKeys();
+        File sshDir = PrivateKeyUtils.getPrivateKeyFolder();
         for (File file : sshDir.listFiles()) {
             jsch.addIdentity(file.getAbsolutePath());
         }


### PR DESCRIPTION
Currently private ssh keys are stored on the sdcard, readable by all applications with sdcard access.  This will store the private keys in internal memory.

Private keys are automatically moved when creating the default activity, the private key management activity, or when the jsch instance is set up.

Fixes bug #49.
