### PR TITLE
Introducing three different version of deleting file

### DIFF
--- a/SGit/res/values/arrays.xml
+++ b/SGit/res/values/arrays.xml
@@ -10,6 +10,8 @@
         <item>Add to stage</item>
         <item>Checkout (Reset Changes)</item>
         <item>Delete</item>
+        <item>Remove cached from repository</item>
+        <item>Remove force from repository</item>
     </string-array>
     <string-array name="repo_operation_names">
         <item>Pull</item>

--- a/SGit/res/values/strings.xml
+++ b/SGit/res/values/strings.xml
@@ -70,7 +70,12 @@
     <string name="dialog_merge_title">Choose Branch To Merge</string>
     <string name="dialog_merge_checkbox">Commit after merge</string>
     <string name="dialog_file_delete">Delete File</string>
-    <string name="dialog_file_delete_msg">Are you sure you want to delete this file or directory?</string>
+    <string name="dialog_file_delete_msg">Are you sure you want to delete this file or directory from working directory?</string>
+    <string name="dialog_file_remove_cached">Remove Cached File</string>
+    <string name="dialog_file_remove_cached_msg">Are you sure you want to delete this file or directory from index?</string>
+    <string name="dialog_file_remove_force">Remove Force File</string>
+    <string name="dialog_file_remove_force_msg">Are you sure you want to delete this file or directory from working directory and index?</string>
+
     <string name="dialog_reset_commit_title">Reset Changes</string>
     <string name="dialog_reset_commit_msg">Are you sure you want to discard all the changes?</string>
     <string name="dialog_create_dir_title">New Directory</string>

--- a/SGit/res/values/strings_success_msg.xml
+++ b/SGit/res/values/strings_success_msg.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <string name="success_add_to_stage">File has been added to stage</string>
+    <string name="success_remove_file">File has been removed</string>
     <string name="success_commit">Changes have been committed</string>
     <string name="success_reset">Changes have been discarded</string>
     <string name="success_cherry_pick">Cherrypicked successfully</string>

--- a/SGit/src/me/sheimi/android/utils/FsUtils.java
+++ b/SGit/src/me/sheimi/android/utils/FsUtils.java
@@ -146,4 +146,8 @@ public class FsUtils {
         return base.toURI().relativize(file.toURI()).getPath();
     }
 
+    public static File joinPath(File dir, String relative_path) {
+        return new File(dir.getAbsolutePath() + File.separator + relative_path);
+    }
+
 }

--- a/SGit/src/me/sheimi/sgit/activities/delegate/RepoOperationDelegate.java
+++ b/SGit/src/me/sheimi/sgit/activities/delegate/RepoOperationDelegate.java
@@ -29,6 +29,8 @@ import me.sheimi.sgit.repo.tasks.repo.MergeTask;
 
 import org.eclipse.jgit.lib.Ref;
 
+import static me.sheimi.sgit.repo.tasks.repo.DeleteFileFromRepoTask.*;
+
 public class RepoOperationDelegate {
 
     private Repo mRepo;
@@ -99,10 +101,10 @@ public class RepoOperationDelegate {
         task.executeTask();
     }
 
-    public void deleteFileFromRepo(String filepath) {
+    public void deleteFileFromRepo(String filepath,DeleteOperationType deleteOperationType) {
         String relative = getRelativePath(filepath);
         DeleteFileFromRepoTask task = new DeleteFileFromRepoTask(mRepo,
-                relative, new AsyncTaskPostCallback() {
+                relative,deleteOperationType, new AsyncTaskPostCallback() {
                     @Override
                     public void onPostExecute(Boolean isSuccess) {
                         // TODO Auto-generated method stub
@@ -117,5 +119,6 @@ public class RepoOperationDelegate {
         String relative = FsUtils.getRelativePath(new File(filepath), base);
         return relative;
     }
+
 
 }

--- a/SGit/src/me/sheimi/sgit/dialogs/RepoFileOperationDialog.java
+++ b/SGit/src/me/sheimi/sgit/dialogs/RepoFileOperationDialog.java
@@ -3,10 +3,14 @@ package me.sheimi.sgit.dialogs;
 import me.sheimi.android.views.SheimiDialogFragment;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.activities.RepoDetailActivity;
+import me.sheimi.sgit.repo.tasks.repo.DeleteFileFromRepoTask;
+
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+
+import static me.sheimi.sgit.repo.tasks.repo.DeleteFileFromRepoTask.*;
 
 /**
  * Created by sheimi on 8/16/13.
@@ -17,6 +21,8 @@ public class RepoFileOperationDialog extends SheimiDialogFragment {
     private static final int ADD_TO_STAGE = 0;
     private static final int CHECKOUT_FILE = 1;
     private static final int DELETE = 2;
+    private static final int REMOVE_CACHED = 3;
+    private static final int REMOVE_FORCE = 4;
     public static final String FILE_PATH = "file path";
     private static String mFilePath;
 
@@ -44,24 +50,44 @@ public class RepoFileOperationDialog extends SheimiDialogFragment {
                                 mActivity.getRepoDelegate().checkoutFile(mFilePath);
                                 break;
                             case DELETE:
-                                showMessageDialog(R.string.dialog_file_delete,
+                                showRemoveFileMessageDialog(R.string.dialog_file_delete,
                                         R.string.dialog_file_delete_msg,
                                         R.string.label_delete,
-                                        new DialogInterface.OnClickListener() {
-                                            @Override
-                                            public void onClick(
-                                                    DialogInterface dialogInterface,
-                                                    int i) {
-                                                mActivity.getRepoDelegate()
-                                                        .deleteFileFromRepo(
-                                                                mFilePath);
-                                            }
-                                        });
+                                        DeleteOperationType.DELETE);
+                                break;
+                            case REMOVE_CACHED:
+                                showRemoveFileMessageDialog(R.string.dialog_file_remove_cached,
+                                        R.string.dialog_file_remove_cached_msg,
+                                        R.string.label_delete,
+                                        DeleteOperationType.REMOVE_CACHED);
+                                break;
+                            case REMOVE_FORCE:
+                                showRemoveFileMessageDialog(R.string.dialog_file_remove_force,
+                                        R.string.dialog_file_remove_force_msg,
+                                        R.string.label_delete,
+                                        DeleteOperationType.REMOVE_FORCE);
                                 break;
                         }
                     }
                 });
 
         return builder.create();
+    }
+
+    private void showRemoveFileMessageDialog(int dialog_title, int dialog_msg, int dialog_positive_button, final DeleteOperationType deleteOperationType) {
+        showMessageDialog(dialog_title,
+                dialog_msg,
+                dialog_positive_button,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(
+                            DialogInterface dialogInterface,
+                            int i) {
+
+                        mActivity.getRepoDelegate()
+                                .deleteFileFromRepo(
+                                        mFilePath, deleteOperationType);
+                    }
+                });
     }
 }


### PR DESCRIPTION
So far deleting file result in same action as 'git rm -f' . User in issues #120 #121 demands actions which are not possible in force delete from repository. I suggest introducing three version od deleting:

* delete - remove file or dir only from working directory ( same as deleting file from drive)
* remove cached - remove file or dir from repository index( same as 'git rm --cached' )
* remove force - remove file or dir from working directory and index (same as 'git rm --force' just like it was)

Those possibilities gives users all options which they would have if they used git from command line

Probably Closes #120,#121