### PR TITLE
Fix contextual menu's button style.

### DIFF
--- a/SGit/res/values/styles_sgit.xml
+++ b/SGit/res/values/styles_sgit.xml
@@ -8,9 +8,9 @@
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-  
+
           http://www.apache.org/licenses/LICENSE-2.0
-  
+
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@
 
 <resources>
 
-    <style name="Theme.Sgit" parent="@android:style/Theme.Holo.Light.DarkActionBar">
+    <style name="Theme.Sgit" parent="@android:style/Theme.Holo.Light">
         <item name="android:actionBarItemBackground">@drawable/selectable_background_sgit</item>
         <item name="android:popupMenuStyle">@style/PopupMenu.Sgit</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Sgit</item>


### PR DESCRIPTION
The buttons in the context menu that is being displayed when
selecting text had a white color. As the menu's background is
white, as well, the buttons were not visible at all.

It turns out this is a bug in the Holo.Light.DarkActionBar theme
(see https://code.google.com/p/android/issues/detail?id=26008).
Change parent theme to Holo.Light to fix the issue.