### PR TITLE
Fix LinkageError on Android Marshmallow

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,10 +4,6 @@
     android:versionCode="107"
     android:versionName="1.2.4.4" >
 
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="19" />
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/src/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/src/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -73,7 +73,7 @@ public class SheimiFragmentActivity extends Activity {
         showToastMessage(getString(resId));
     }
 
-    public int getColor(int resId) {
+    public int getResColor(int resId) {
         return getResources().getColor(resId);
     }
 

--- a/src/me/sheimi/sgit/adapters/CommitsListAdapter.java
+++ b/src/me/sheimi/sgit/adapters/CommitsListAdapter.java
@@ -95,7 +95,7 @@ public class CommitsListAdapter extends SheimiArrayAdapter<RevCommit> {
     private int getColor(int resId) {
         Context context = getContext();
         if (context instanceof SheimiFragmentActivity) {
-            return ((SheimiFragmentActivity) context).getColor(resId);
+            return ((SheimiFragmentActivity) context).getResColor(resId);
         }
         return 0;
     }


### PR DESCRIPTION
Fix crash caused by LinkageError on Marshmallow:
```
FATAL EXCEPTION: main
Process: me.sheimi.sgit, PID: 14620
java.lang.LinkageError: me.sheimi.sgit.RepoListActivity
    at dalvik.system.DexFile.defineClassNative(Native Method)
    at dalvik.system.DexFile.defineClass(DexFile.java:226)
    at dalvik.system.DexFile.loadClassBinaryName(DexFile.java:219)
    at dalvik.system.DexPathList.findClass(DexPathList.java:338)
    at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:54)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:511)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:469)
    at android.app.Instrumentation.newActivity(Instrumentation.java:1067)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2317)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
    at android.app.ActivityThread.-wrap11(ActivityThread.java)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:148)
    at android.app.ActivityThread.main(ActivityThread.java:5417)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
    at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:134)
```