### PR TITLE
Fix translations

### DIFF
--- a/res/values-de/arrays.xml
+++ b/res/values-de/arrays.xml
@@ -10,6 +10,8 @@
         <item>Zum Staging-Bereich hinzufügen</item>
         <item>Auschecken (Änderungen zurücksetzen)</item>
         <item>Löschen</item>
+        <item>Remove cached from repository</item>
+        <item>Remove force from repository</item>
     </string-array>
     <string-array name="repo_operation_names">
         <item>Neuer Branch</item>
@@ -25,6 +27,10 @@
         <item>Neue Datei</item>
         <item>Neuer Ordner</item>
         <item>Remote Repository hinzufügen</item>
+        <item>Löschen</item>
+    </string-array>
+    <string-array name="dialog_choose_repo_action_items">
+        <item>Rename</item>
         <item>Löschen</item>
     </string-array>
 

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -85,5 +85,28 @@
 
     <!-- toast msg -->
     <string name="feedback_subject">Feedback</string>
+    <string name="action_open_in_other_app">Open in other apps</string>
+    <string name="alert_have_paid">Ads have been removed</string>
+    <string name="default_text">Standardtext</string>
+    <string name="dialog_choose_option">Wählen Sie die Option ...</string>
+    <string name="dialog_clone_recursive">Clone rekursiv</string>
+    <string name="dialog_create_branch_hint">Zweigname</string>
+    <string name="dialog_create_branch_title">Erstellen Sie neue Niederlassung</string>
+    <string name="hello_world">Hallo Welt!</string>
+    <string name="pull_msg_init">Ziehen …</string>
+    <string name="push_msg_init">schieben …</string>
+    <string name="success_remove_file">Datei wurde entfernt</string>
+    <string name="error_rename_repo_fail">Umbenennen Repository fehlgeschlagen</string>
+    <string name="dialog_rename_repo_hint">Repository-Name</string>
+    <string name="dialog_rename_repo_title">Benennen Sie Repository</string>
+    <string name="title_section1"> Abschnitt 1</string>
+    <string name="title_section2"> Abschnitt 2</string>
+    <string name="title_section3">Abschnitt 3</string>
+    <string name="dialog_file_remove_cached">Entfernen Sie Cache-Datei</string>
+    <string name="dialog_file_remove_cached_msg">Sind Sie sicher, dass Sie diese Datei oder ein Verzeichnis aus dem Index zu löschen?</string>
+    <string name="dialog_file_remove_force">Entfernen Sie Force-Datei</string>
+    <string name="dialog_file_remove_force_msg">Sind Sie sicher, dass Sie diese Datei oder ein Verzeichnis zu löschen, aus Arbeitsverzeichnis und Index?</string>
+    <string name="progress_left_init">0%</string>
+    <string name="progress_right_init">0/0</string>
 
 </resources>

--- a/res/values-de/strings_dialog.xml
+++ b/res/values-de/strings_dialog.xml
@@ -35,7 +35,7 @@
     <string name="dialog_add_remote_positive_label">Fertig</string>
 
     <!-- Push -->
-    <string name="dialog_push_repo_title">Veröffentlichen nach &#8230;</string>
+    <string name="dialog_push_repo_title">Veröffentlichen nach ...</string>
     <string name="dialog_push_repo_msg">Die lokalen Änderungen wirklich veröffentlichen?</string>
     <string name="dialog_push_is_push_all">Alles veröffentlichen?</string>
     <string name="dialog_push_is_force_push">Veröffentlichung erzwingen?</string>

--- a/res/values-fr/arrays.xml
+++ b/res/values-fr/arrays.xml
@@ -12,6 +12,7 @@
         <item>Supprimer</item>
     </string-array>
     <string-array name="repo_operation_names">
+        <item>New Branch</item>
         <item>Pull</item>
         <item>Push</item>
         <item>Add all to stage</item>

--- a/res/values-fr/arrays.xml
+++ b/res/values-fr/arrays.xml
@@ -10,6 +10,8 @@
         <item>Add to stage</item>
         <item>Checkout (Reset Changes)</item>
         <item>Supprimer</item>
+        <item>Remove cached from repository</item>
+        <item>Remove force from repository</item>
     </string-array>
     <string-array name="repo_operation_names">
         <item>New Branch</item>
@@ -25,6 +27,10 @@
         <item>Nouveau fichier</item>
         <item>Nouveau dépôt</item>
         <item>Add remote</item>
+        <item>Supprimer</item>
+    </string-array>
+    <string-array name="dialog_choose_repo_action_items">
+        <item>Rename</item>
         <item>Supprimer</item>
     </string-array>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -94,5 +94,39 @@
 
     <!-- toast msg -->
     <string name="feedback_subject">Feedback</string>
+    <string name="action_open_in_other_app">Open in other apps</string>
+    <string name="alert_no_older_commits"> Aucun ancien engage à comparer avec</string>
+    <string name="alert_file_exists">Le fichier existe déjà</string>
+    <string name="alert_filename_format">Fichier erreur de format de nom</string>
+    <string name="dialog_add_remote_hint_name">nom à distance</string>
+    <string name="dialog_add_remote_hint_url">URL à distance</string>
+    <string name="dialog_add_remote_title"> Ajouter à distance</string>
+    <string name="dialog_choose_option"> Choisissez l\'option ...</string>
+    <string name="dialog_clone_recursive">Clone récursive</string>
+    <string name="dialog_commit_auto_stage">étape automatique des fichiers modifiés</string>
+    <string name="dialog_commit_is_amend">Modifier engagement précédent</string>
+    <string name="dialog_commit_msg_hint">Engagez un message</string>
+    <string name="dialog_commit_positive_label">Consigner </string>
+    <string name="dialog_commit_title">Soumettre les changements</string>
+    <string name="dialog_create_branch_hint">Nom de la filiale</string>
+    <string name="dialog_create_branch_title">Créer nouvelle branche</string>
+    <string name="dialog_create_external_msg">Voulez-vous créer un dépôt Git dans ce répertoire?</string>
+    <string name="success_remove_file">Le fichier a été supprimé</string>
+    <string name="success_remote_added">Distant ajouté</string>
+    <string name="error_rename_repo_fail">référentiel Renommage échoué</string>
+    <string name="error_no_edit_app">Aucune application peut modifier le fichier source</string>
+    <string name="error_no_open_app">Aucune application peut ouvrir le fichier source</string>
+    <string name="error_can_not_open_file">Vous ne pouvez pas ouvrir ce fichier dans ce dispositif.</string>
+    <string name="error_can_not_edit_file">Vous ne pouvez pas éditer ce fichier dans ce dispositif.</string>
+    <string name="dialog_push_is_force_push">Force de poussée?</string>
+    <string name="dialog_push_is_push_all">Poussez tous?</string>
+    <string name="dialog_push_repo_msg">Etes-vous sûr de vouloir pousser les changements locaux?</string>
+    <string name="dialog_push_repo_title">Pousser à ...</string>
+    <string name="dialog_rename_repo_hint">Dépôt nom</string>
+    <string name="dialog_rename_repo_title">renommez Dépôt </string>
+    <string name="dialog_file_remove_cached">Supprimer le fichier cache</string>
+    <string name="dialog_file_remove_cached_msg">Êtes-vous sûr de vouloir supprimer ce fichier ou le répertoire de l\'index?</string>
+    <string name="dialog_file_remove_force">Supprimer le fichier de travail</string>
+    <string name="dialog_file_remove_force_msg">Êtes-vous sûr de vouloir supprimer ce fichier ou le répertoire à partir du répertoire et de l\'indice de travail?</string>
 
 </resources>

--- a/res/values-iw/arrays.xml
+++ b/res/values-iw/arrays.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string-array name="merge_ff_type">
+    <item>Fast Forward</item>
+    <item>Fast Forward Only</item>
+    <item>No Fast Forward</item>
+  </string-array>
   <string-array name="repo_file_operations">
     <item>הוסף לשלב</item>
     <item>בדיקה (אפס שינויים)</item>
     <item>מחק</item>
+    <item>Remove cached from repository</item>
+    <item>Remove force from repository</item>
   </string-array>
   <string-array name="repo_operation_names">
     <item>סניף חדש</item>
@@ -19,6 +26,10 @@
     <item>קובץ חדש</item>
     <item>תיקייה חדשה</item>
     <item>הוסף שרת</item>
+    <item>מחק</item>
+  </string-array>
+  <string-array name="dialog_choose_repo_action_items">
+    <item>Rename</item>
     <item>מחק</item>
   </string-array>
 </resources>

--- a/res/values-iw/arrays.xml
+++ b/res/values-iw/arrays.xml
@@ -6,6 +6,7 @@
     <item>מחק</item>
   </string-array>
   <string-array name="repo_operation_names">
+    <item>סניף חדש</item>
     <item>משוך</item>
     <item>דחוף</item>
     <item>הוסף את כולם לשלב</item>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -76,4 +76,25 @@
   <string name="title_activity_private_key_manage">נהל מפתחות פרטיים</string>
   <string name="title_activity_explore_file">חקור קבצים</string>
   <string name="feedback_subject">משוב</string>
+  <string name="action_open_in_other_app">Open in other apps</string>
+  <string name="dialog_cherrypick_title">Cherry Pick</string>
+  <string name="dialog_choose_option">בחר באפשרות ...</string>
+  <string name="dialog_clone_recursive">clone באופן רקורסיבי</string>
+  <string name="dialog_create_branch_hint">שם הסניף</string>
+  <string name="dialog_create_branch_title">צור סניף חדש</string>
+  <string name="success_remove_file">קובץ הוסר</string>
+  <string name="tab_commits_label">מבצע</string>
+  <string name="title_activity_repo_detail">מאגר</string>
+  <string name="error_rename_repo_fail">מאגר שינוי שם נכשל</string>
+  <string name="dialog_push_is_force_push">לדחוף בכוח?</string>
+  <string name="dialog_rename_repo_hint">שם מאגר</string>
+  <string name="dialog_rename_repo_title">שינוי שם Repository</string>
+  <string name="dialog_file_remove_cached">הסר קובץ Cached</string>
+  <string name="dialog_file_remove_cached_msg">האם אתה בטוח שברצונך למחוק את הקובץ או בספריה זו מהאינדקס?</string>
+  <string name="dialog_file_remove_force">הסר קובץ חיל</string>
+  <string name="dialog_file_remove_force_msg">האם אתה בטוח שאתה רוצה למחוק קובץ זה או ספריית מעבודה ספרייה ואינדקס?</string>
+  <string name="dialog_label_cherrypick">פיק שרי</string>
+  <string name="hello_world">שלום עולם!</string>
+  <string name="progress_left_init">0%</string>
+  <string name="progress_right_init">0/0</string>
 </resources>

--- a/res/values-iw/strings_dialog.xml
+++ b/res/values-iw/strings_dialog.xml
@@ -19,7 +19,7 @@
   <string name="dialog_add_remote_hint_name">שם שרת</string>
   <string name="dialog_add_remote_hint_url">URL שרת</string>
   <string name="dialog_add_remote_positive_label">הושלם</string>
-  <string name="dialog_push_repo_title">דחוף ל-&#8230;</string>
+  <string name="dialog_push_repo_title">דחוף ל-...</string>
   <string name="dialog_push_repo_msg">האם אתה בטוח שברצונך להעלות שינויים אחרונים?</string>
   <string name="dialog_push_is_push_all">להעלות הכל?</string>
   <string name="dialog_push_result">דחוף תוצאה</string>

--- a/res/values-ja/arrays.xml
+++ b/res/values-ja/arrays.xml
@@ -12,6 +12,7 @@
         <item>Delete</item>
     </string-array>
     <string-array name="repo_operation_names">
+        <item>New Branch</item>
         <item>Pull</item>
         <item>Push</item>
         <item>Add all to stage</item>

--- a/res/values-ja/arrays.xml
+++ b/res/values-ja/arrays.xml
@@ -10,6 +10,8 @@
         <item>Add to stage</item>
         <item>Checkout (Reset Changes)</item>
         <item>Delete</item>
+        <item>Remove cached from repository</item>
+        <item>Remove force from repository</item>
     </string-array>
     <string-array name="repo_operation_names">
         <item>New Branch</item>
@@ -25,6 +27,10 @@
         <item>New File</item>
         <item>New Directory</item>
         <item>Add Remote</item>
+        <item>Delete</item>
+    </string-array>
+    <string-array name="dialog_choose_repo_action_items">
+        <item>Rename</item>
         <item>Delete</item>
     </string-array>
 

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -94,5 +94,19 @@
 
     <!-- toast msg -->
     <string name="feedback_subject">フィードバック</string>
+    <string name="action_open_in_other_app">Open in other apps</string>
+    <string name="dialog_create_branch_hint">支店名</string>
+    <string name="dialog_create_branch_title">新しいブランチを作成します。</string>
+    <string name="success_remove_file">ファイルが削除されました</string>
+    <string name="error_rename_repo_fail">名前の変更リポジトリに失敗しました</string>
+    <string name="dialog_choose_option">オプションを選択します...</string>
+    <string name="dialog_clone_recursive">再帰的に複製します</string>
+    <string name="dialog_push_is_force_push">力のプッシュ？</string>
+    <string name="dialog_rename_repo_hint">リポジトリ名</string>
+    <string name="dialog_rename_repo_title">リポジトリの名前を変更します</string>
+    <string name="dialog_file_remove_cached">キャッシュされたファイルを削除します</string>
+    <string name="dialog_file_remove_cached_msg">あなたは、インデックスからこのファイルまたはディレクトリを削除してもよろしいですか？</string>
+    <string name="dialog_file_remove_force">強制ファイルの削除</string>
+    <string name="dialog_file_remove_force_msg">あなたはディレクトリとインデックス作業からこのファイルまたはディレクトリを削除してもよろしいですか？</string>
 
 </resources>

--- a/res/values-ja/strings_dialog.xml
+++ b/res/values-ja/strings_dialog.xml
@@ -35,7 +35,7 @@
     <string name="dialog_add_remote_positive_label">完了</string>
 
     <!-- Push -->
-    <string name="dialog_push_repo_title"> &#8230;にプッシュ</string>
+    <string name="dialog_push_repo_title">...にプッシュ</string>
     <string name="dialog_push_repo_msg">ローカルでの変更をプッシュしてもよろしいですか?</string>
     <string name="dialog_push_is_push_all">全てプッシュしますか ?</string>
     <string name="dialog_push_result">プッシュ結果</string>

--- a/res/values-zh-rCN/arrays.xml
+++ b/res/values-zh-rCN/arrays.xml
@@ -12,6 +12,7 @@
         <item>删除</item>
     </string-array>
     <string-array name="repo_operation_names">
+        <item>新的分支</item>
         <item>拉取</item>
         <item>推送</item>
         <item>添加到暂存区</item>

--- a/res/values-zh-rCN/arrays.xml
+++ b/res/values-zh-rCN/arrays.xml
@@ -10,6 +10,8 @@
         <item>添加到暂存区</item>
         <item>检出 (重置更改)</item>
         <item>删除</item>
+        <item>Remove cached from repository</item>
+        <item>Remove force from repository</item>
     </string-array>
     <string-array name="repo_operation_names">
         <item>新的分支</item>
@@ -25,6 +27,10 @@
         <item>新建文件</item>
         <item>新建文件夹</item>
         <item>远程</item>
+        <item>删除</item>
+    </string-array>
+    <string-array name="dialog_choose_repo_action_items">
+        <item>Rename</item>
         <item>删除</item>
     </string-array>
 

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">SGit</string>
     <string name="default_text">默认文字</string>
     <string name="title_clone_repo">克隆仓库</string>
-    <string name="preference_file_key">me.sheimi.sgit</string>
 
     <!-- action -->
     <string name="action_search">查找</string>
@@ -96,5 +94,19 @@
 
     <!-- toast msg -->
     <string name="feedback_subject">反馈</string>
+    <string name="action_open_in_other_app">Open in other apps</string>
+    <string name="alert_have_paid">Ads have been removed</string>
+    <string name="dialog_create_branch_hint">分店名称</string>
+    <string name="dialog_create_branch_title">创建新的分支</string>
+    <string name="success_remove_file">文件已被删除</string>
+    <string name="error_rename_repo_fail">重命名库失败</string>
+    <string name="dialog_choose_option">选择选项...</string>
+    <string name="dialog_clone_recursive">递归克隆</string>
+    <string name="dialog_rename_repo_hint">库名</string>
+    <string name="dialog_rename_repo_title">重命名库</string>
+    <string name="dialog_file_remove_cached">删除缓存的文件</string>
+    <string name="dialog_file_remove_cached_msg">你确定要删除这个索引文件或目录？</string>
+    <string name="dialog_file_remove_force">删除文件力</string>
+    <string name="dialog_file_remove_force_msg">你确定要删除工作目录和索引文件或目录？</string>
 
 </resources>

--- a/res/values-zh-rCN/strings_dialog.xml
+++ b/res/values-zh-rCN/strings_dialog.xml
@@ -35,7 +35,7 @@
     <string name="dialog_add_remote_positive_label">完成</string>
 
     <!-- Push -->
-    <string name="dialog_push_repo_title">推送到 &#8230;</string>
+    <string name="dialog_push_repo_title">推送到 ...</string>
     <string name="dialog_push_repo_msg">你确定推送本地的修改？</string>
     <string name="dialog_push_is_push_all">全部推送？</string>
     <string name="dialog_push_is_force_push">强制推送？</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">SGit</string>
+    <string name="app_name" translatable="false">SGit</string>
     <string name="default_text">Default Text</string>
     <string name="title_clone_repo">Clone Repository</string>
-    <string name="preference_file_key">me.sheimi.sgit</string>
+    <string name="preference_file_key" translatable="false">me.sheimi.sgit</string>
 
     <!-- action -->
     <string name="action_search">Search</string>
@@ -107,4 +107,6 @@
 
     <!-- toast msg -->
     <string name="feedback_subject">Feedback</string>
+    <string name="action_edit">Edit</string>
+    <string name="alert_have_paid">Ads have been removed</string>
 </resources>

--- a/res/values/strings_dialog.xml
+++ b/res/values/strings_dialog.xml
@@ -35,7 +35,7 @@
     <string name="dialog_add_remote_positive_label">Done</string>
 
     <!-- Push -->
-    <string name="dialog_push_repo_title">Push to &#8230;</string>
+    <string name="dialog_push_repo_title">Push to ...</string>
     <string name="dialog_push_repo_msg">Are you sure you want to push local changes?</string>
     <string name="dialog_push_is_push_all">Push all?</string>
     <string name="dialog_push_is_force_push">Force push?</string>


### PR DESCRIPTION
Fix translation issues as reported by Lint which without an override prevent a release APK being built.
Missing translation string and string-array resources have been added,  translated mostly using mechanical translation so need review by native language speakers.